### PR TITLE
Fix audit entity detection and mapper reference

### DIFF
--- a/src/main/java/br/com/fazmerir/entities/Despesa.java
+++ b/src/main/java/br/com/fazmerir/entities/Despesa.java
@@ -29,6 +29,6 @@ public class Despesa implements AuditableEntity {
 
     @Override
     public boolean isNew() {
-        return false;
+        return this.id == null;
     }
 }

--- a/src/main/java/br/com/fazmerir/entities/Receita.java
+++ b/src/main/java/br/com/fazmerir/entities/Receita.java
@@ -46,6 +46,6 @@ public class Receita implements AuditableEntity {
 
     @Override
     public boolean isNew() {
-        return false;
+        return this.id == null;
     }
 }

--- a/src/main/java/br/com/fazmerir/entities/Saldo.java
+++ b/src/main/java/br/com/fazmerir/entities/Saldo.java
@@ -31,6 +31,6 @@ public class Saldo implements AuditableEntity {
 
     @Override
     public boolean isNew() {
-        return false;
+        return this.id == null;
     }
 }

--- a/src/main/java/br/com/fazmerir/mapper/DespesaMapper.java
+++ b/src/main/java/br/com/fazmerir/mapper/DespesaMapper.java
@@ -9,7 +9,7 @@ import org.mapstruct.factory.Mappers;
 @Mapper(componentModel = "spring")
 public interface DespesaMapper {
 
-    ReceitaMapper INSTANCE = Mappers.getMapper(ReceitaMapper.class);
+    DespesaMapper INSTANCE = Mappers.getMapper(DespesaMapper.class);
 
 Despesa toEntity(DespesaDto dto);
 DespesaDto toDto(Despesa entity);


### PR DESCRIPTION
## Summary
- fix `isNew` method to correctly detect new entities
- correct self-reference in `DespesaMapper`

## Testing
- `mvn -q -DskipTests -Djava.net.preferIPv4Stack=true package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684431ac8a60832c954d2c7a06974fc6